### PR TITLE
Bump operator v1.3.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,13 @@
 {
   "name": "stakewise-operator-holesky.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v1.3.0",
-  "upstreamRepo": "stakewise/v3-operator",
+  "upstream": [
+    {
+      "repo": "stakewise/v3-operator",
+      "version": "v1.3.2",
+      "arg": "UPSTREAM_VERSION"
+    }
+  ],
   "description": "StakeWise V3 allows anyone who is capable of running Ethereum validators to participate in liquid staking and receive staking delegations from others.",
   "type": "service",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: operator
       args:
-        UPSTREAM_VERSION: v1.3.0
+        UPSTREAM_VERSION: v1.3.2
     restart: unless-stopped
     volumes:
       - stakewise:/app/data/stakewise


### PR DESCRIPTION
Bump operator to `v1.3.2` and set new upstream repo format. Overrides https://github.com/dappnode/DAppNodePackage-stakewise-operator-holesky/pull/53